### PR TITLE
Add support to application module with name different `app`

### DIFF
--- a/annotation/build.gradle
+++ b/annotation/build.gradle
@@ -24,7 +24,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'com.flownav'
             artifactId = 'annotation'
-            version = '0.4.1'
+            version = '0.4.2'
             from components.java
         }
     }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -41,7 +41,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'com.flownav'
             artifactId = 'processor'
-            version = '0.4.1'
+            version = '0.4.2'
             from components.java
         }
     }

--- a/router/build.gradle
+++ b/router/build.gradle
@@ -47,7 +47,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'com.flownav'
             artifactId = 'router'
-            version = '0.4.1'
+            version = '0.4.2'
             artifact("$buildDir/outputs/aar/router-release.aar")
         }
     }

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -22,3 +22,5 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 org.gradle.parallel=true
+
+flownav.main.module=app


### PR DESCRIPTION
If other module is used as `application` module (instead of  the`app` module), now is supported by FlowNav with the property `flownav.main.module` on `gradle.properties` file.